### PR TITLE
Allow setting camera geometry for SSD modes in the starting window #10

### DIFF
--- a/include/cameraselectdialog.h
+++ b/include/cameraselectdialog.h
@@ -81,11 +81,11 @@ public:
         dimButtonLayout->addWidget(cancelDimButton);
 
         QHBoxLayout *xLayout = new QHBoxLayout;
-        xLayout->addWidget(new QLabel("X:"));
+        xLayout->addWidget(new QLabel("Width:"));
         xLayout->addWidget(horizontal);
 
         QHBoxLayout *yLayout = new QHBoxLayout;
-        yLayout->addWidget(new QLabel("Y:"));
+        yLayout->addWidget(new QLabel("Height:"));
         yLayout->addWidget(vertical);
 
         QVBoxLayout *dimDialogLayout = new QVBoxLayout(dim_dialog);

--- a/include/cameraselectdialog.h
+++ b/include/cameraselectdialog.h
@@ -62,10 +62,10 @@ public:
         dim_dialog->setWindowTitle("Select Input Dimensions");
 
         horizontal = new QLineEdit;
-        horizontal->setText(s->value(QString("ssd_x"), "").toString());
+        horizontal->setText(s->value(QString("ssd_width"), "").toString());
 
         vertical = new QLineEdit;
-        vertical->setText(s->value(QString("ssd_y"), "").toString());
+        vertical->setText(s->value(QString("ssd_height"), "").toString());
 
         QPushButton *okDimButton = new QPushButton("&Ok", dim_dialog);
         connect(okDimButton, &QPushButton::clicked,
@@ -112,8 +112,8 @@ private slots:
 
     void dim_accept()
     {
-        s->setValue(QString("ssd_x"), horizontal->text());
-        s->setValue(QString("ssd_y"), vertical->text());
+        s->setValue(QString("ssd_width"), horizontal->text());
+        s->setValue(QString("ssd_height"), vertical->text());
         this->accept();
     }
 

--- a/include/image_type.h
+++ b/include/image_type.h
@@ -6,7 +6,7 @@
 
 enum image_t {BASE, DSF, STD_DEV, SPATIAL_PROFILE, SPECTRAL_PROFILE, SPATIAL_MEAN, SPECTRAL_MEAN};
 
-enum camera_t {DEFAULT, SSD_XIO, CL_6604A, CL_6604B};
+enum camera_t {DEFAULT, SSD_XIO, SSD_ENVI, CL_6604A, CL_6604B};
 
 enum source_t {
     SSD = 0,

--- a/src/frameworker.cpp
+++ b/src/frameworker.cpp
@@ -74,7 +74,9 @@ FrameWorker::FrameWorker(QSettings *settings_arg, QThread *worker, QObject *pare
 
     switch(static_cast<source_t>(settings->value(QString("cam_model")).toInt())) {
     case SSD:
-        Camera = new SSDCamera();
+        Camera = new SSDCamera(settings->value(QString("ssd_width"), 640).toUInt(),
+                               settings->value(QString("ssd_height"), 480).toUInt(),
+                               settings->value(QString("ssd_height"), 480).toUInt());
         break;
     case DEBUG:
         Camera = new ENVICamera();


### PR DESCRIPTION
# Allow setting camera geometry for SSD modes in the starting window #10
This is mostly the front-end, as the back-end task this depends on is not finished.