### PR TITLE
interleave string in header bugfix

### DIFF
--- a/LiveView.pro
+++ b/LiveView.pro
@@ -26,7 +26,7 @@ TEMPLATE = app
 
 # You can compile LiveView with EDTpdv. In order to do so, uncomment the following line and make sure
 # EDT is in your working directory
-# DEFINES += USE_EDT
+DEFINES += USE_EDT
 
 QMAKE_CXXFLAGS -= -std=gnu++11
 QMAKE_CXXFLAGS += -O3 -std=c++0x -Wno-inconsistent-missing-override -Wno-ignored-attributes -Wno-date-time

--- a/src/frameworker.cpp
+++ b/src/frameworker.cpp
@@ -297,6 +297,7 @@ void FrameWorker::saveFrames(save_req_t req)
     int64_t new_count = 0;
     std::vector<uint16_t> p_frame;
     std::string hdr_fname;
+    std::string interleave;
     save_count.store(0);
 
     std::vector<float> frame_accum;
@@ -314,12 +315,15 @@ void FrameWorker::saveFrames(save_req_t req)
     switch(req.bit_org) {
     case fwBIL:
         p_getSaveFrame = &FrameWorker::getBILSaveFrame;
+        interleave = "bil";
         break;
     case fwBIP:
         p_getSaveFrame = &FrameWorker::getBIPSaveFrame;
+        interleave = "bip";
         break;
     case fwBSQ:
         p_getSaveFrame = &FrameWorker::getBILSaveFrame; // BSQ conversion is done at the end.
+        interleave = "bsq";
     }
 
     std::ofstream p_file;
@@ -365,7 +369,8 @@ void FrameWorker::saveFrames(save_req_t req)
     hdr_text += "lines   = " + std::to_string(req.nFrames / req.nAvgs) + "\n";
     hdr_text += "bands   = " + std::to_string(dataHeight) + "\n";
     hdr_text += "header offset = 0\nfile type = ENVI Standard\ndata type = 12\n";
-    hdr_text += "interleave = " + std::to_string(req.bit_org) + "\n";
+    hdr_text += "interleave = " + interleave + "\n";
+    //hdr_text += "interleave = " + std::to_string(req.bit_org) + "\n";
     hdr_text += "sensor type = Unknown\nbyte order = 0\nwavelength units = Unknown\n";
 
     std::ofstream hdr_out(hdr_fname);

--- a/src/frameworker.cpp
+++ b/src/frameworker.cpp
@@ -364,7 +364,7 @@ void FrameWorker::saveFrames(save_req_t req)
     }
 
     std::string hdr_text = "ENVI\ndescription = {LIVEVIEW raw export file, " +
-            std::to_string(req.nFrames) + " frame mean per acquisition}\n";
+            std::to_string(req.nAvgs) + " frame mean per acquisition}\n";
     hdr_text += "samples = " + std::to_string(frWidth) + "\n";
     hdr_text += "lines   = " + std::to_string(req.nFrames / req.nAvgs) + "\n";
     hdr_text += "bands   = " + std::to_string(dataHeight) + "\n";


### PR DESCRIPTION
This would create an interleave variable and assign a bil\bip\bsq value to it, then write it out to the header.